### PR TITLE
Remove old option and add missing display index in make_app

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ using namespace Cute;
 int main(int argc, char* argv[])
 {
 	// Create a window with a resolution of 640 x 480.
-	int options = APP_OPTIONS_DEFAULT_GFX_CONTEXT | APP_OPTIONS_WINDOW_POS_CENTERED;
+	int options = APP_OPTIONS_WINDOW_POS_CENTERED;
 	Result result = make_app("Fancy Window Title", 0, 0, 0, 640, 480, options, argv[0]);
 	if (is_error(result)) return -1;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,8 +4,8 @@ using namespace Cute;
 int main(int argc, char* argv[])
 {
 	// Create a window with a resolution of 640 x 480.
-	int options = APP_OPTIONS_DEFAULT_GFX_CONTEXT | APP_OPTIONS_WINDOW_POS_CENTERED;
-	Result result = make_app("Fancy Window Title", 0, 0, 640, 480, options, argv[0]);
+	int options = APP_OPTIONS_WINDOW_POS_CENTERED;
+	Result result = make_app("Fancy Window Title", 0, 0, 0, 640, 480, options, argv[0]);
 	if (is_error(result)) return -1;
 
 	while (app_is_running())


### PR DESCRIPTION
Currently, building this project fails because when calling `make_app`:

1. an old app option is used (`APP_OPTIONS_DEFAULT_GFX_CONTEXT`)
2. it is missing an argument for the display index 

This PR removes `APP_OPTIONS_DEFAULT_GFX_CONTEXT` and adds a display index (`0`) in `make_app`.